### PR TITLE
Enhance GitHub profile README with stats and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
-### Hi there
+### Hi there 👋
 
-> [!IMPORTANT]
-> I'm not young enough to know everything
+I'm **Romain Lespinasse**, a developer based in Lille, France.
 
-See more on [https://www.romainlespinasse.dev/about](https://www.romainlespinasse.dev/about/)
+> *I'm not young enough to know everything*
+
+---
+
+<p>
+  <a href="https://github-readme-stats.vercel.app">
+    <img height="160" src="https://github-readme-stats.vercel.app/api?username=rlespinasse&show_icons=true&hide_border=true&bg_color=00000000&title_color=58a6ff&icon_color=58a6ff&text_color=c9d1d9" alt="GitHub Stats" />
+  </a>
+  <a href="https://git.io/streak-stats">
+    <img height="160" src="https://github-readme-streak-stats.herokuapp.com?user=rlespinasse&hide_border=true&background=00000000&ring=58a6ff&fire=58a6ff&currStreakLabel=58a6ff&sideLabels=c9d1d9&currStreakNum=c9d1d9&sideNums=c9d1d9&dates=c9d1d9" alt="GitHub Streak" />
+  </a>
+</p>
+
+---
+
+#### Highlighted Projects
+
+| Project | Description |
+|---------|-------------|
+| [**github-slug-action**](https://github.com/rlespinasse/github-slug-action) | ![Stars](https://img.shields.io/github/stars/rlespinasse/github-slug-action?style=flat-square&color=58a6ff) Expose slug values of GitHub environment variables |
+| [**drawio-export**](https://github.com/rlespinasse/drawio-export) | ![Stars](https://img.shields.io/github/stars/rlespinasse/drawio-export?style=flat-square&color=58a6ff) Export Draw.io diagrams using Docker |
+| [**docker-drawio-desktop-headless**](https://github.com/rlespinasse/docker-drawio-desktop-headless) | ![Stars](https://img.shields.io/github/stars/rlespinasse/docker-drawio-desktop-headless?style=flat-square&color=58a6ff) Headless version of drawio-desktop |
+| [**drawio-export-action**](https://github.com/rlespinasse/drawio-export-action) | ![Stars](https://img.shields.io/github/stars/rlespinasse/drawio-export-action?style=flat-square&color=58a6ff) GitHub Action for exporting Draw.io files |
+| [**drawio-exporter**](https://github.com/rlespinasse/drawio-exporter) | ![Stars](https://img.shields.io/github/stars/rlespinasse/drawio-exporter?style=flat-square&color=58a6ff) CLI tool for Draw.io file exports, written in Rust |
+
+---
+
+[![Website](https://img.shields.io/badge/romainlespinasse.dev-252525?style=for-the-badge&logo=safari&logoColor=white)](https://www.romainlespinasse.dev)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/romain-lespinasse)
+[![Sponsor](https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/rlespinasse)


### PR DESCRIPTION
## Summary
Completely redesigned the GitHub profile README to provide a more comprehensive and visually appealing introduction, including GitHub statistics, highlighted projects, and social links.

## Key Changes
- **Personal introduction**: Added name, location, and professional context
- **GitHub statistics**: Integrated GitHub Stats and Streak Stats cards with custom styling (GitHub dark theme colors)
- **Highlighted projects section**: Added a table showcasing 5 major projects with descriptions and star badges:
  - github-slug-action
  - drawio-export
  - docker-drawio-desktop-headless
  - drawio-export-action
  - drawio-exporter
- **Social links**: Added badge-style links to personal website, LinkedIn profile, and GitHub Sponsors
- **Improved formatting**: Enhanced visual hierarchy with horizontal dividers and better typography

## Notable Details
- Used consistent color scheme (GitHub's blue `#58a6ff` and light gray `#c9d1d9`) for badges and stats
- Embedded dynamic star count badges for each project using shields.io
- Maintained the original quote while improving its presentation
- Replaced plain text link with styled badge buttons for better visual consistency

https://claude.ai/code/session_01NGqssnXD4Mmsai7XNxdGHB