### PR TITLE
Add 2026 projects list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ I'm **Romain Lespinasse**, a developer based in Lille, France.
 
 ---
 
+#### 2026 Projects
+
+| Project | Description |
+|---------|-------------|
+| [**agent-skills**](https://github.com/rlespinasse/agent-skills) | ![Stars](https://img.shields.io/github/stars/rlespinasse/agent-skills?style=flat-square&color=58a6ff) A collection of Agent Skills for AI coding assistants (Claude, Cursor, Copilot) |
+| [**github-actions-toolbox**](https://github.com/rlespinasse/github-actions-toolbox) | ![Stars](https://img.shields.io/github/stars/rlespinasse/github-actions-toolbox?style=flat-square&color=58a6ff) CLI toolbox for GitHub Actions |
+| [**homebrew-tap**](https://github.com/rlespinasse/homebrew-tap) | ![Stars](https://img.shields.io/github/stars/rlespinasse/homebrew-tap?style=flat-square&color=58a6ff) Homebrew tap for installing @rlespinasse tools and utilities |
+| [**bassin-minier-unesco**](https://github.com/rlespinasse/bassin-minier-unesco) | ![Stars](https://img.shields.io/github/stars/rlespinasse/bassin-minier-unesco?style=flat-square&color=58a6ff) Carte interactive du Bassin minier du Nord-Pas de Calais, patrimoine mondial de l'UNESCO |
+| [**leaflet-atlas**](https://github.com/rlespinasse/leaflet-atlas) | ![Stars](https://img.shields.io/github/stars/rlespinasse/leaflet-atlas?style=flat-square&color=58a6ff) A config-driven Leaflet framework for building interactive GeoJSON map applications |
+| [**morvan**](https://github.com/rlespinasse/morvan) | ![Stars](https://img.shields.io/github/stars/rlespinasse/morvan?style=flat-square&color=58a6ff) |
+
+---
+
 [![Website](https://img.shields.io/badge/romainlespinasse.dev-252525?style=for-the-badge&logo=safari&logoColor=white)](https://www.romainlespinasse.dev)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/romain-lespinasse)
 [![Sponsor](https://img.shields.io/badge/Sponsor-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/rlespinasse)


### PR DESCRIPTION
Include the 6 repositories created in 2026: agent-skills,
github-actions-toolbox, homebrew-tap, bassin-minier-unesco,
leaflet-atlas, and morvan.

https://claude.ai/code/session_016fKaZV4ixhfnTUzdhCNvkQ