### PR TITLE
Automate README project lists with GitHub Actions

### DIFF
--- a/.github/scripts/update-readme.sh
+++ b/.github/scripts/update-readme.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITHUB_USER="rlespinasse"
+README_FILE="README.md"
+TARGET_YEAR="2026"
+HIGHLIGHTED_COUNT=5
+
+generate_table_row() {
+  local repo="$1"
+  local description="$2"
+  # Sanitize pipe characters in descriptions to avoid breaking markdown tables
+  description="${description//|/\\|}"
+  echo "| [**${repo}**](https://github.com/${GITHUB_USER}/${repo}) | ![Stars](https://img.shields.io/github/stars/${GITHUB_USER}/${repo}?style=flat-square&color=58a6ff) ${description} |"
+}
+
+update_highlighted_projects() {
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  # Fetch all public non-fork repos, output: stars<TAB>repo_name<TAB>description
+  gh api "users/${GITHUB_USER}/repos" \
+    --paginate \
+    --jq '.[] | select(.fork == false and .private == false) | [(.stargazers_count | tostring), .name, (.description // "")] | @tsv' \
+    > "$tmpfile"
+
+  local table_content
+  table_content="| Project | Description |
+|---------|-------------|"
+
+  # Sort by stars descending, take top N
+  while IFS=$'\t' read -r stars repo description; do
+    table_content="${table_content}
+$(generate_table_row "$repo" "$description")"
+  done < <(sort -t$'\t' -k1 -nr "$tmpfile" | head -n "$HIGHLIGHTED_COUNT")
+
+  rm "$tmpfile"
+  echo "$table_content"
+}
+
+update_year_projects() {
+  local tmpfile
+  tmpfile=$(mktemp)
+
+  # Fetch public non-fork repos created in TARGET_YEAR
+  # Output: created_at<TAB>repo_name<TAB>description
+  gh api "users/${GITHUB_USER}/repos" \
+    --paginate \
+    --jq ".[] | select(.fork == false and .private == false and (.created_at | startswith(\"${TARGET_YEAR}\"))) | [.created_at, .name, (.description // \"\")] | @tsv" \
+    > "$tmpfile"
+
+  local table_content
+  table_content="| Project | Description |
+|---------|-------------|"
+
+  # Sort by creation date descending (newest first)
+  while IFS=$'\t' read -r created_at repo description; do
+    table_content="${table_content}
+$(generate_table_row "$repo" "$description")"
+  done < <(sort -t$'\t' -k1 -r "$tmpfile")
+
+  rm "$tmpfile"
+  echo "$table_content"
+}
+
+replace_section() {
+  local start_marker="$1"
+  local end_marker="$2"
+  local new_content="$3"
+  local file="$4"
+
+  awk -v start="$start_marker" -v end="$end_marker" -v content="$new_content" '
+    $0 == start { print; printf "%s\n", content; skip=1; next }
+    $0 == end   { print; skip=0; next }
+    !skip       { print }
+  ' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+}
+
+# --- Main ---
+echo "Updating Highlighted Projects (top ${HIGHLIGHTED_COUNT} by stars)..."
+highlighted_content=$(update_highlighted_projects)
+replace_section "<!-- HIGHLIGHTED_PROJECTS:START -->" "<!-- HIGHLIGHTED_PROJECTS:END -->" "$highlighted_content" "$README_FILE"
+
+echo "Updating ${TARGET_YEAR} Projects (sorted by creation date, newest first)..."
+year_content=$(update_year_projects)
+replace_section "<!-- YEAR_PROJECTS:START -->" "<!-- YEAR_PROJECTS:END -->" "$year_content" "$README_FILE"
+
+echo "README updated."

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,30 @@
+name: Update README
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update README sections
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/update-readme.sh
+
+      - name: Commit and push if changed
+        run: |
+          git diff --quiet README.md && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs: update README project lists"
+          git push

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I'm **Romain Lespinasse**, a developer based in Lille, France.
 
 #### Highlighted Projects
 
+<!-- HIGHLIGHTED_PROJECTS:START -->
 | Project | Description |
 |---------|-------------|
 | [**github-slug-action**](https://github.com/rlespinasse/github-slug-action) | ![Stars](https://img.shields.io/github/stars/rlespinasse/github-slug-action?style=flat-square&color=58a6ff) Expose slug values of GitHub environment variables |
@@ -26,11 +27,13 @@ I'm **Romain Lespinasse**, a developer based in Lille, France.
 | [**docker-drawio-desktop-headless**](https://github.com/rlespinasse/docker-drawio-desktop-headless) | ![Stars](https://img.shields.io/github/stars/rlespinasse/docker-drawio-desktop-headless?style=flat-square&color=58a6ff) Headless version of drawio-desktop |
 | [**drawio-export-action**](https://github.com/rlespinasse/drawio-export-action) | ![Stars](https://img.shields.io/github/stars/rlespinasse/drawio-export-action?style=flat-square&color=58a6ff) GitHub Action for exporting Draw.io files |
 | [**drawio-exporter**](https://github.com/rlespinasse/drawio-exporter) | ![Stars](https://img.shields.io/github/stars/rlespinasse/drawio-exporter?style=flat-square&color=58a6ff) CLI tool for Draw.io file exports, written in Rust |
+<!-- HIGHLIGHTED_PROJECTS:END -->
 
 ---
 
 #### 2026 Projects
 
+<!-- YEAR_PROJECTS:START -->
 | Project | Description |
 |---------|-------------|
 | [**agent-skills**](https://github.com/rlespinasse/agent-skills) | ![Stars](https://img.shields.io/github/stars/rlespinasse/agent-skills?style=flat-square&color=58a6ff) A collection of Agent Skills for AI coding assistants (Claude, Cursor, Copilot) |
@@ -39,6 +42,7 @@ I'm **Romain Lespinasse**, a developer based in Lille, France.
 | [**bassin-minier-unesco**](https://github.com/rlespinasse/bassin-minier-unesco) | ![Stars](https://img.shields.io/github/stars/rlespinasse/bassin-minier-unesco?style=flat-square&color=58a6ff) Carte interactive du Bassin minier du Nord-Pas de Calais, patrimoine mondial de l'UNESCO |
 | [**leaflet-atlas**](https://github.com/rlespinasse/leaflet-atlas) | ![Stars](https://img.shields.io/github/stars/rlespinasse/leaflet-atlas?style=flat-square&color=58a6ff) A config-driven Leaflet framework for building interactive GeoJSON map applications |
 | [**morvan**](https://github.com/rlespinasse/morvan) | ![Stars](https://img.shields.io/github/stars/rlespinasse/morvan?style=flat-square&color=58a6ff) |
+<!-- YEAR_PROJECTS:END -->
 
 ---
 


### PR DESCRIPTION
## Summary
This PR adds automation to keep the README's project lists up-to-date by introducing a GitHub Actions workflow that periodically updates highlighted and year-specific project sections.

## Key Changes
- **New GitHub Actions Workflow** (`.github/workflows/update-readme.yml`):
  - Scheduled to run weekly on Mondays at 06:00 UTC
  - Manually triggerable via `workflow_dispatch`
  - Automatically commits and pushes changes if README is modified

- **New Update Script** (`.github/scripts/update-readme.sh`):
  - Fetches public non-fork repositories from GitHub API
  - **Highlighted Projects**: Displays top 5 repositories sorted by star count
  - **2026 Projects**: Displays repositories created in 2026, sorted by creation date (newest first)
  - Generates markdown tables with repository links and star badges
  - Safely handles special characters (pipes) in descriptions to prevent markdown table corruption
  - Uses temporary files for data processing and cleanup

- **README Updates**:
  - Added HTML comment markers (`<!-- HIGHLIGHTED_PROJECTS:START/END -->` and `<!-- YEAR_PROJECTS:START/END -->`) to define sections for automated updates
  - Existing project tables are now wrapped with these markers for safe replacement

## Notable Implementation Details
- Uses `gh api` with pagination to fetch all repositories regardless of count
- Implements robust section replacement using `awk` to preserve surrounding content
- Properly escapes pipe characters in descriptions to maintain markdown table integrity
- Uses `set -euo pipefail` for safe bash script execution
- Leverages GitHub's default `GITHUB_TOKEN` for API authentication
- Commits use the standard `github-actions[bot]` identity

https://claude.ai/code/session_01XFqeeM2qLtDgEkPL7fiyie