### PR TITLE
Enable Dependabot for GitHub Actions with weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update README sections
         env:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Update README sections
         env:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update README sections
         env:


### PR DESCRIPTION
## Summary
This PR enables Dependabot to automatically manage GitHub Actions dependencies with weekly update checks.

## Key Changes
- Added `.github/dependabot.yml` configuration file to enable Dependabot for the `github-actions` package ecosystem with weekly update intervals
- Updated `actions/checkout` from v4 to v6 in the `update-readme.yml` workflow, including the commit hash for reproducibility

## Implementation Details
- Dependabot is configured to check for updates to GitHub Actions dependencies once per week
- The checkout action upgrade includes a pinned commit hash (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`) alongside the version tag for enhanced security and reproducibility

https://claude.ai/code/session_0184uQp5rSe6bMG78QpWhncT